### PR TITLE
Fix location of benchmarks sources

### DIFF
--- a/compilation/src/main/scala/scala/tools/nsc/BloopReflect.scala
+++ b/compilation/src/main/scala/scala/tools/nsc/BloopReflect.scala
@@ -1,0 +1,21 @@
+package scala.tools.nsc
+
+import java.nio.file.Path
+
+object BloopReflect {
+
+  /**
+   * Returns the `.bloop-config` directory for project `name`.
+   *
+   * This is done through reflection, because otherwise we would need to add a dependency
+   * from this project to Bloop's tests. We just need to be careful to call it only once
+   * per fork.
+   */
+  def getBloopConfigDir(name: String): Path = {
+    val classLoader = getClass.getClassLoader
+    val projectHelpers = classLoader.loadClass("bloop.tasks.ProjectHelpers")
+    val method = projectHelpers.getMethod("getBloopConfigDir", classOf[String])
+    method.invoke(null, name).asInstanceOf[Path]
+  }
+
+}

--- a/compilation/src/main/scala/scala/tools/nsc/HotSbtBenchmark.scala
+++ b/compilation/src/main/scala/scala/tools/nsc/HotSbtBenchmark.scala
@@ -62,7 +62,7 @@ class HotSbtBenchmark {
        |}""".stripMargin
 
   @Setup(Level.Trial) def spawn(): Unit = {
-    path = Paths.get(s"../integration-tests/integration-projects/$project")
+    path = BloopReflect.getBloopConfigDir(project).getParent
     cleanClassesPath = path.resolve("project").resolve("CleanClassesPlugin.scala")
     Files.write(cleanClassesPath, cleanClassesPlugin.getBytes("UTF-8"))
     val sbtLaucherPath = System.getProperty("sbt.launcher")

--- a/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
+++ b/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
@@ -35,12 +35,13 @@ class ScalacBenchmark extends BenchmarkDriver {
 
   override def isResident = resident
 
+  private var base: Path = _
+
   var depsClasspath: String = _
 
   def sourceFiles: List[String] = {
     import scala.collection.JavaConverters._
-    val path = Paths.get(s"../integration-tests/integration-projects/$project/$projectName")
-    val allFiles = Files.walk(path, FileVisitOption.FOLLOW_LINKS).collect(Collectors.toList[Path]).asScala.toList
+    val allFiles = Files.walk(base, FileVisitOption.FOLLOW_LINKS).collect(Collectors.toList[Path]).asScala.toList
     val files = allFiles.filter(f => {
       val name = f.getFileName.toString
       name.endsWith(".scala") || name.endsWith(".java")
@@ -56,6 +57,7 @@ class ScalacBenchmark extends BenchmarkDriver {
     tempFile.delete()
     tempFile.mkdir()
     tempDir = tempFile
+    base = BloopReflect.getBloopConfigDir(project).getParent.resolve(projectName)
   }
   @TearDown(Level.Trial) def clearTemp(): Unit = {
     BenchmarkUtils.deleteRecursive(tempDir.toPath)


### PR DESCRIPTION
The location of the benchmark sources changed when we improved our
integration testing infrastructure, but the change wasn't reflected in
the benchmarks.

Because the location of the sources can no longer be known in advance,
we need to use the utilities defined in the test suite of Bloop.
Unfortunately, this project doesn't depend on it.

We use reflection to call these utilities. We just need to be careful to
call them at most once per fork.