### PR TITLE
refactor: don't include the sbt-bloop-build

### DIFF
--- a/infrastructure/src/main/resources/reference.conf
+++ b/infrastructure/src/main/resources/reference.conf
@@ -1,5 +1,5 @@
 influx {
-  url = "http://10.90.36.34:8086"
+  url = "http://10.90.40.6:8086"
   user = "bloop_benchmark"
   # If unset, a fallback will use a matching entry from `~/.netrc`
   #

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,24 +5,11 @@ logLevel := Level.Warn
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.3")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.14")
 
-// Enable this for the bloop build to work
-//addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13-2")
-
 // required for java9+
 val javaxActivation = "com.sun.activation" % "javax.activation" % "1.2.0"
 
-//addSbtPlugin("ch.epfl.scala" % "sbt-bloop-build" % "1.0.0-SNAPSHOT")
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 
 libraryDependencies ++= List(
   javaxActivation
 )
-
-val `bloop-shaded-plugin` = project
-  .settings(
-    sbtPlugin := true,
-    exportJars := true,
-    libraryDependencies += "ch.epfl.scala" %% "sbt-bloop-build-naked" % "1.0.0-SNAPSHOT"
-  )
-
-dependsOn(`bloop-shaded-plugin`)


### PR DESCRIPTION
There is no real reason to do this (from what I can tell) since everything that is needed to actually run the benchmarks are set up on the Bloop side. I've fairly sure that this use case is just like the other use case in Bloop where we want to dogfood sbt-bloop so we do all sorts of stuff just to include it. By removing this it allows us to fully just get rid of all the publishing of the naked/shaded meta meta build stuff.

I'll have a more detailed explanation in https://github.com/scalacenter/bloop/pull/1956